### PR TITLE
fix:  React Select helper value attribute in option tag

### DIFF
--- a/react/Select/index.js
+++ b/react/Select/index.js
@@ -48,7 +48,8 @@ module.exports = React.createClass({
     props.onBlur = this.onBlur
     return React.createElement('select', props, this.state.options.map(function (option, index) {
       return React.createElement('option', {
-        key: index
+        key: index,
+        value: option.value
       }, option.text)
     }))
   }


### PR DESCRIPTION
The value attribute of the select tag was not rendered. This resulted in setting the state to the text rather than value of the option object. With this fix you explicitly tell react to render the value attribute.
