### PR TITLE
feat(dependents): change API to dependsOn with full paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,16 +103,17 @@ export default (options = {}) {
           isEmail: true
         }],
         errorMessages: ['Please enter a valid email address'],
-        dependents: [
-          ['..', 'email3'],
-          //['checkout', 'customer', 'email3'] this could point to another form.
-          //['.', '..', 'email3'] // Also works
-        ]
+        // Revalidate this field when email3 changes.
+        // Use full path to field, allows nested and cross form
+        // dependencies
+        dependsOn: 'app.myForm.email3',
+        // Multiple dependsOn
+        dependsOn: ['app.myForm.email3', 'app.someOtherForm.email4']
       },
       email3: {
         value: '',
         isRequired: true,
-        validations: ['equalsField:"email2"', 'isEmail'],
+        validations: ['equalsField:email2', 'isEmail'],
         errorMessages: ['Please enter the same email address as above',
                         'Please enter a valid email address']
       },
@@ -204,7 +205,7 @@ export default connect(
   },
   function Form ({signals, form}) {
     const isValid = isValidForm(form);
-    
+
     return (
       <form>
         <div>

--- a/actions/validate.js
+++ b/actions/validate.js
@@ -24,6 +24,7 @@ function validate (arg) {
   doValidation(path, form, key)
 
   if (Array.isArray(field.dependents) && field.dependents.length) {
+    console.warn('DEPRECATED: Use new field.dependsOn API instead');
     field.dependents.forEach(function (dependent) {
       if (!Array.isArray(dependent) || !dependent.length) {
         console.warn('cerebral-module-forms: dependent path expected to be Array. Check out dependents provided for ' + input.field + '.')
@@ -35,6 +36,22 @@ function validate (arg) {
 
       doValidation(path, form, key)
     })
+  }
+
+  if (Array.isArray(field.dependsOn)) {
+    field.dependsOn.forEach(function (stringPath) {
+      var path = stringPath.split('.')
+      var key = path.pop()
+      var form = state.get(path)
+
+      doValidation(path, form, key)
+    })
+  } else if (field.dependsOn) {
+    var path = field.dependsOn.split('.')
+    var key = path.pop()
+    var form = state.get(path)
+
+    doValidation(path, form, key)
   }
 }
 

--- a/demo/components/Simple/Form/index.js
+++ b/demo/components/Simple/Form/index.js
@@ -44,6 +44,39 @@ class Form extends React.Component {
         </div>
 
         <div>
+          <h4>Password (required)</h4>
+          <input
+            value={form.email.password}
+            onChange={(e) => signals.forms.fieldChanged({
+              field: 'simple.password',
+              value: e.target.value
+            })}
+            onBlur={(e) => signals.forms.fieldChanged({
+              field: 'simple.password',
+              value: e.target.value,
+              touched: true
+            })}/>
+          {form.email.isTouched ? form.password.errorMessage : null}
+        </div>
+
+        <div>
+          <h4>Repeat password (required)</h4>
+          <input
+            type="password"
+            value={form.email.repeatPassword}
+            onChange={(e) => signals.forms.fieldChanged({
+              field: 'simple.repeatPassword',
+              value: e.target.value
+            })}
+            onBlur={(e) => signals.forms.fieldChanged({
+              field: 'simple.repeatPassword',
+              value: e.target.value,
+              touched: true
+            })}/>
+          {form.email.isTouched ? form.repeatPassword.errorMessage : null}
+        </div>
+
+        <div>
           <h4>Address</h4>
           <div>
             <h5>Street</h5>

--- a/demo/modules/Simple/index.js
+++ b/demo/modules/Simple/index.js
@@ -14,6 +14,20 @@ export default (options = {}) => {
         errorMessages: ['Not valid email'],
         isRequired: true
       },
+      password: {
+        value: '',
+        validations: ['equalsField:repeatPassword'],
+        dependsOn: 'simple.repeatPassword',
+        errorMessages: ['Not equal to repeated password'],
+        isRequired: true
+      },
+      repeatPassword: {
+        value: '',
+        validations: ['equalsField:password'],
+        dependsOn: 'simple.password',
+        errorMessages: ['Not equal to password'],
+        isRequired: true
+      },
       address: Form({
         street: {
           value: ''

--- a/helpers/validate.js
+++ b/helpers/validate.js
@@ -21,7 +21,15 @@ module.exports = function (form, value, validations) {
         var args = validation.split(/:(.+)?/)
 
         validation = {}
-        validation[args[0]] = args[1] ? JSON.parse(args[1]) : undefined
+        if (args[1]) {
+          try {
+            validation[args[0]] = JSON.parse(args[1])
+          } catch (e) {
+            validation[args[0]] = args[1]
+          }
+        } else {
+          validation[args[0]] = undefined
+        }
       }
 
       return {


### PR DESCRIPTION
BREAKING CHANGE:
- Replaces dependents API

The dependents API is a good concept, but API is quite confusing. With this change we will rather:

``` js
// PATH: app.form
{
  fieldA: {
    value: '',
    dependsOn: 'app.form.fieldB'
  },
  fieldB: {
    value: ''
  }
}
```

Or you can use an array to depend on multiple fields. This allows you to depend on nested, parent or even cross forms.
